### PR TITLE
Switch to MD5 keys

### DIFF
--- a/tpl-NKI_res-01_T1w.nii.gz
+++ b/tpl-NKI_res-01_T1w.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/2V/87/URL-s43131574--https&c%%files.osf.io%v1%resourc-389c568079306fb3ac5f6713f700e8c2/URL-s43131574--https&c%%files.osf.io%v1%resourc-389c568079306fb3ac5f6713f700e8c2
+.git/annex/objects/zw/6w/MD5E-s43131570--123a3182be83428b3457003f4d71edee.nii.gz/MD5E-s43131570--123a3182be83428b3457003f4d71edee.nii.gz

--- a/tpl-NKI_res-01_desc-6_dseg.nii.gz
+++ b/tpl-NKI_res-01_desc-6_dseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/F8/mz/URL-s293010--https&c%%files.osf.io%v1%resourc-966699597be1076b63f7af02c1a04127/URL-s293010--https&c%%files.osf.io%v1%resourc-966699597be1076b63f7af02c1a04127
+.git/annex/objects/9V/v5/MD5E-s293419--75d39884bc6bc85f3b328c407adb8859.nii.gz/MD5E-s293419--75d39884bc6bc85f3b328c407adb8859.nii.gz

--- a/tpl-NKI_res-01_desc-BrainCerebellumExtraction_mask.nii.gz
+++ b/tpl-NKI_res-01_desc-BrainCerebellumExtraction_mask.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/wZ/f8/URL-s206030--https&c%%files.osf.io%v1%resourc-47e62ae8f44f04c6fb46f655292b5f86/URL-s206030--https&c%%files.osf.io%v1%resourc-47e62ae8f44f04c6fb46f655292b5f86
+.git/annex/objects/wF/k7/MD5E-s206044--bf10a0b1e2b88947d30a4ece149ff995.nii.gz/MD5E-s206044--bf10a0b1e2b88947d30a4ece149ff995.nii.gz

--- a/tpl-NKI_res-01_desc-BrainCerebellumRegistration_mask.nii.gz
+++ b/tpl-NKI_res-01_desc-BrainCerebellumRegistration_mask.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/9q/4k/URL-s193396--https&c%%files.osf.io%v1%resourc-87fab497e17f77ca3962e07eea0442c0/URL-s193396--https&c%%files.osf.io%v1%resourc-87fab497e17f77ca3962e07eea0442c0
+.git/annex/objects/Qq/Wk/MD5E-s193433--0a8cfccb972941b05376980420a4de38.nii.gz/MD5E-s193433--0a8cfccb972941b05376980420a4de38.nii.gz

--- a/tpl-NKI_res-01_desc-brain_T1w.nii.gz
+++ b/tpl-NKI_res-01_desc-brain_T1w.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/XP/FV/URL-s4886614--https&c%%files.osf.io%v1%resourc-4881703366904f5259bc97a7c55e427b/URL-s4886614--https&c%%files.osf.io%v1%resourc-4881703366904f5259bc97a7c55e427b
+.git/annex/objects/x2/33/MD5E-s4886610--52a7eee0600088d104d8b2a9a51b40a6.nii.gz/MD5E-s4886610--52a7eee0600088d104d8b2a9a51b40a6.nii.gz

--- a/tpl-NKI_res-01_desc-brain_mask.nii.gz
+++ b/tpl-NKI_res-01_desc-brain_mask.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/Vp/Mx/URL-s152238--https&c%%files.osf.io%v1%resourc-74eba7bc96e2e1578a0c74f8c02b757b/URL-s152238--https&c%%files.osf.io%v1%resourc-74eba7bc96e2e1578a0c74f8c02b757b
+.git/annex/objects/WV/kM/MD5E-s152242--3c0da5dc3ca154924c5e148232104c11.nii.gz/MD5E-s152242--3c0da5dc3ca154924c5e148232104c11.nii.gz

--- a/tpl-NKI_res-01_desc-malf_dseg.nii.gz
+++ b/tpl-NKI_res-01_desc-malf_dseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/W9/WW/URL-s336791--https&c%%files.osf.io%v1%resourc-c35b69db56c2d04ce42208094b923f2d/URL-s336791--https&c%%files.osf.io%v1%resourc-c35b69db56c2d04ce42208094b923f2d
+.git/annex/objects/34/wg/MD5E-s336562--19b6a85d8647f17027016a1d26038988.nii.gz/MD5E-s336562--19b6a85d8647f17027016a1d26038988.nii.gz

--- a/tpl-NKI_res-01_label-BS_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-BS_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/P6/zG/URL-s190168--https&c%%files.osf.io%v1%resourc-0efb52fd2a13f5553272f8c5e0d43837/URL-s190168--https&c%%files.osf.io%v1%resourc-0efb52fd2a13f5553272f8c5e0d43837
+.git/annex/objects/fg/03/MD5E-s364086--e589aa60449e5750a6ade06f0744b01b.nii.gz/MD5E-s364086--e589aa60449e5750a6ade06f0744b01b.nii.gz

--- a/tpl-NKI_res-01_label-CBM_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-CBM_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/PW/p0/URL-s498253--https&c%%files.osf.io%v1%resourc-7473b5dd8e3cc85a5dacc05970d4e261/URL-s498253--https&c%%files.osf.io%v1%resourc-7473b5dd8e3cc85a5dacc05970d4e261
+.git/annex/objects/59/19/MD5E-s683774--11203415b284a7225513103a7aee3a85.nii.gz/MD5E-s683774--11203415b284a7225513103a7aee3a85.nii.gz

--- a/tpl-NKI_res-01_label-CGM_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-CGM_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/m5/M4/URL-s3925609--https&c%%files.osf.io%v1%resourc-759237657bb2d8b7177eee74318ebc84/URL-s3925609--https&c%%files.osf.io%v1%resourc-759237657bb2d8b7177eee74318ebc84
+.git/annex/objects/v2/12/MD5E-s4138427--89bacdf22b70958e0a73bf81d8d3db69.nii.gz/MD5E-s4138427--89bacdf22b70958e0a73bf81d8d3db69.nii.gz

--- a/tpl-NKI_res-01_label-CSF_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-CSF_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/xf/0x/URL-s6090347--https&c%%files.osf.io%v1%resourc-575b032ad9b64b218e3e3a1580b39ce2/URL-s6090347--https&c%%files.osf.io%v1%resourc-575b032ad9b64b218e3e3a1580b39ce2
+.git/annex/objects/wg/5j/MD5E-s6276041--add007514abd880e330d8f08ad1ed597.nii.gz/MD5E-s6276041--add007514abd880e330d8f08ad1ed597.nii.gz

--- a/tpl-NKI_res-01_label-SCGM_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-SCGM_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/8M/q1/URL-s483339--https&c%%files.osf.io%v1%resourc-ee0c18181dcf0c96c4f28d774e9bb31d/URL-s483339--https&c%%files.osf.io%v1%resourc-ee0c18181dcf0c96c4f28d774e9bb31d
+.git/annex/objects/46/qM/MD5E-s661929--d77f54a48205fab6684676c057cdaf1d.nii.gz/MD5E-s661929--d77f54a48205fab6684676c057cdaf1d.nii.gz

--- a/tpl-NKI_res-01_label-WM_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-WM_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/zg/g3/URL-s3956289--https&c%%files.osf.io%v1%resourc-89a88134978428adde7b6e04326cf300/URL-s3956289--https&c%%files.osf.io%v1%resourc-89a88134978428adde7b6e04326cf300
+.git/annex/objects/18/Xj/MD5E-s4181153--e90c5f00d2913acdda75b6960d1ebeaa.nii.gz/MD5E-s4181153--e90c5f00d2913acdda75b6960d1ebeaa.nii.gz

--- a/tpl-NKI_res-01_label-brainNoCerebellum_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-brainNoCerebellum_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/82/p3/URL-s3148499--https&c%%files.osf.io%v1%resourc-d554eee3f896835e7a9f20c8160895b8/URL-s3148499--https&c%%files.osf.io%v1%resourc-d554eee3f896835e7a9f20c8160895b8
+.git/annex/objects/Gg/VP/MD5E-s3148516--b9b1472c4b655760cf90b381711b9a20.nii.gz/MD5E-s3148516--b9b1472c4b655760cf90b381711b9a20.nii.gz

--- a/tpl-NKI_res-01_label-brain_probseg.nii.gz
+++ b/tpl-NKI_res-01_label-brain_probseg.nii.gz
@@ -1,1 +1,1 @@
-.git/annex/objects/z0/x7/URL-s2378079--https&c%%files.osf.io%v1%resourc-f0288414e7e679f16e83b308abb720a8/URL-s2378079--https&c%%files.osf.io%v1%resourc-f0288414e7e679f16e83b308abb720a8
+.git/annex/objects/vG/Qf/MD5E-s2378077--8f41d4b9a72a62a0994bb2136f5458d3.nii.gz/MD5E-s2378077--8f41d4b9a72a62a0994bb2136f5458d3.nii.gz


### PR DESCRIPTION
Switching to MD5 keys in Datalad (`fast=False`) as per @yarikoptic 's suggestion appears to resolve #1. I've updated my OSF interface utility functions to use this option from now on, and I can update the remaining templates to use MD5 as well. There is a separate PR for the `git-annex` branch.